### PR TITLE
refactor: move Cosmos DB setup and seed to services/database

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,9 +4,10 @@
 
 Industrial IoT tag registry with three layers and an orchestrated agent system:
 
-- **`server/`** — Python FastAPI backend. Domain models (Pydantic), Cosmos DB persistence, REST API, deterministic naming validator, suggest-name orchestrator.
+- **`server/`** — Python FastAPI backend. Domain models (Pydantic), Cosmos DB query logic (repository layer), REST API, deterministic naming validator, suggest-name orchestrator. **Standalone deployable** — never imports from `services/`.
 - **`client/`** — React 19 + TypeScript + Vite frontend. Fluent UI v9 component library. Dev server proxies `/api/*` to `localhost:8000`.
-- **`services/`** — Standalone Python modules for Azure AI integrations:
+- **`services/`** — Local-only Python modules for Azure service setup and configuration. **Not deployed** — used during development to create infrastructure, seed data, and configure external services. Has its own `requirements.txt` and venv.
+  - `services/database/` — Cosmos DB setup: container creation (`cosmos_setup.py`) and data seeding (`seed.py`).
   - `services/search/` — Azure AI Search: vector index creation, golden tag seeding, hybrid suggest-name queries.
   - `services/language/` — Language detection and normalisation to English.
 - **`.github/agents/`** — Copilot agent orchestration. `ot-builder` orchestrator delegates to `ob--backend-api`, `ob--frontend`, and `ob--ai-search` subagents.
@@ -24,8 +25,11 @@ cd server && uv run uvicorn src.main:app --reload --port 8000
 cd client && npm install
 cd client && npm run dev          # Vite dev server on port 5173
 
+# Services (local-only setup tools)
+cd services && uv venv && uv pip install -r requirements.txt
+
 # Seed sample data into Cosmos DB
-cd server && uv run python -m src.scripts.seed
+cd services && uv run python -m database.seed
 
 # AI Search services
 cd services/search && uv venv && uv pip install -r requirements.txt
@@ -47,6 +51,12 @@ cd server && uv run pytest tests/ -k "test_name"  # Single test by name
 ```
 
 ## Key Conventions
+
+### Server vs. Services Separation
+
+- **`server/`** is a **standalone deployable API**. It contains only runtime logic: routes, models, repository (query layer), validators. It never imports from `services/`.
+- **`services/`** is **local-only** — used during development for infrastructure setup (DB container creation, data seeding, AI Search index creation). Not deployed with the server.
+- Non-API service configurations (Cosmos DB setup, AI Search index management, data seeding) always live in `services/`, never in `server/`.
 
 ### Python (server + services)
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Required variables:
 ```bash
 # Install dependencies
 cd server && uv venv && uv pip install -r requirements.txt
+cd ../services && uv venv && uv pip install -r requirements.txt
 cd ../client && npm install
 
 # Start backend (port 8000)
@@ -104,7 +105,7 @@ cd client && npm run dev
 The seed script populates your Cosmos DB with realistic sample data for development and demo purposes:
 
 ```bash
-cd server && uv run python -m src.scripts.seed
+cd services && uv run python -m database.seed
 ```
 
 This will:
@@ -119,8 +120,9 @@ This will:
 ```
 ot-tag-registry/
 ├── client/          # React + Vite + TypeScript frontend
-├── server/          # Python (FastAPI) backend API
-└── services/        # Azure service integrations
+├── server/          # Python (FastAPI) backend API (standalone deployable)
+└── services/        # Local-only setup tools (not deployed)
+    ├── database/    # Cosmos DB container creation + data seeding
     ├── search/      # Azure AI Search (vector index)
     └── language/    # Language normalisation (optional)
 ```

--- a/server/src/config/cosmos.py
+++ b/server/src/config/cosmos.py
@@ -1,21 +1,13 @@
 import logging
 import os
 
-from azure.cosmos import CosmosClient, DatabaseProxy, PartitionKey
+from azure.cosmos import CosmosClient, DatabaseProxy
 
 logger = logging.getLogger("cosmos.config")
 
 COSMOS_ENDPOINT = os.environ.get("COSMOS_ENDPOINT", "")
 COSMOS_KEY = os.environ.get("COSMOS_KEY", "")
 COSMOS_DATABASE = os.environ.get("COSMOS_DATABASE", "ot-tag-registry")
-
-CONTAINERS: dict[str, str] = {
-    "assets": "/site",
-    "tags": "/assetId",
-    "sources": "/systemType",
-    "l1Rules": "/tagId",
-    "l2Rules": "/tagId",
-}
 
 
 def get_cosmos_client() -> CosmosClient:
@@ -43,20 +35,3 @@ def get_database(client: CosmosClient | None = None) -> DatabaseProxy:
 def get_container(container_name: str, client: CosmosClient | None = None):
     db = get_database(client)
     return db.get_container_client(container_name)
-
-
-def ensure_containers(client: CosmosClient | None = None) -> DatabaseProxy:
-    """Create database and all containers if they don't exist."""
-    if client is None:
-        client = get_cosmos_client()
-    db = client.create_database_if_not_exists(COSMOS_DATABASE)
-    for name, pk_path in CONTAINERS.items():
-        logger.info("Ensuring container '%s' with partition key '%s'", name, pk_path)
-        db.create_container_if_not_exists(
-            id=name,
-            partition_key=PartitionKey(path=pk_path),
-        )
-    logger.info(
-        "Database '%s' ready with %d containers", COSMOS_DATABASE, len(CONTAINERS)
-    )
-    return db

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -6,10 +6,10 @@ import logging
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
-from fastapi import Depends, FastAPI, Request
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
-from src.config.cosmos import ensure_containers, get_cosmos_client, get_database
+from src.config.cosmos import get_cosmos_client, get_database
 
 logging.basicConfig(
     level=logging.INFO,
@@ -24,7 +24,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # --- startup ---
     try:
         client = get_cosmos_client()
-        ensure_containers(client)
         app.state.cosmos_client = client
         logger.info("Cosmos DB connection established")
     except Exception as e:

--- a/services/database/__init__.py
+++ b/services/database/__init__.py
@@ -1,0 +1,5 @@
+"""services.database — Local-only Cosmos DB setup and seeding tools.
+
+NOT deployed with the server. Used during development to create
+containers, seed sample data, and run database migrations.
+"""

--- a/services/database/cosmos_setup.py
+++ b/services/database/cosmos_setup.py
@@ -1,0 +1,57 @@
+"""Cosmos DB setup utilities — container creation and database initialisation.
+
+This module is used locally during development, NOT at server runtime.
+The server assumes containers already exist.
+"""
+
+import logging
+import os
+
+from azure.cosmos import CosmosClient, DatabaseProxy, PartitionKey
+
+logger = logging.getLogger("cosmos.setup")
+
+COSMOS_ENDPOINT = os.environ.get("COSMOS_ENDPOINT", "")
+COSMOS_KEY = os.environ.get("COSMOS_KEY", "")
+COSMOS_DATABASE = os.environ.get("COSMOS_DATABASE", "ot-tag-registry")
+
+CONTAINERS: dict[str, str] = {
+    "assets": "/site",
+    "tags": "/assetId",
+    "sources": "/systemType",
+    "l1Rules": "/tagId",
+    "l2Rules": "/tagId",
+}
+
+
+def get_cosmos_client() -> CosmosClient:
+    """Create and return a Cosmos DB client, validating env vars first."""
+    if not COSMOS_ENDPOINT or not COSMOS_KEY:
+        logger.error(
+            "COSMOS_ENDPOINT and COSMOS_KEY must be set (endpoint=%r)",
+            COSMOS_ENDPOINT,
+        )
+        raise ValueError("COSMOS_ENDPOINT and COSMOS_KEY must be set")
+    try:
+        client = CosmosClient(COSMOS_ENDPOINT, credential=COSMOS_KEY)
+        return client
+    except Exception as e:
+        logger.error("Failed to connect to Cosmos DB at %s: %s", COSMOS_ENDPOINT, e)
+        raise
+
+
+def ensure_containers(client: CosmosClient | None = None) -> DatabaseProxy:
+    """Create database and all containers if they don't exist."""
+    if client is None:
+        client = get_cosmos_client()
+    db = client.create_database_if_not_exists(COSMOS_DATABASE)
+    for name, pk_path in CONTAINERS.items():
+        logger.info("Ensuring container '%s' with partition key '%s'", name, pk_path)
+        db.create_container_if_not_exists(
+            id=name,
+            partition_key=PartitionKey(path=pk_path),
+        )
+    logger.info(
+        "Database '%s' ready with %d containers", COSMOS_DATABASE, len(CONTAINERS)
+    )
+    return db

--- a/services/database/seed.py
+++ b/services/database/seed.py
@@ -8,15 +8,24 @@ Populates:
   • 5  L2 state-profile rules (pump pressures, motor speeds)
 
 Usage:
-    cd server
-    uv run python -m src.scripts.seed
+    cd services
+    uv run python -m database.seed
 """
+
+import sys
+from pathlib import Path
+
+# Resolve repo root for cross-package imports and .env loading
+_repo_root = Path(__file__).resolve().parent.parent.parent
 
 from dotenv import load_dotenv
 
-load_dotenv()
+load_dotenv(_repo_root / "server" / ".env")
 
-from src.config.cosmos import ensure_containers, get_cosmos_client
+# Add server/ to sys.path for cross-package imports (local-only)
+sys.path.insert(0, str(_repo_root / "server"))
+
+from database.cosmos_setup import ensure_containers, get_cosmos_client
 from src.models import (
     Asset,
     Tag,

--- a/services/requirements.txt
+++ b/services/requirements.txt
@@ -1,0 +1,3 @@
+azure-cosmos
+python-dotenv
+pydantic


### PR DESCRIPTION
## Summary

Moves Cosmos DB setup tooling out of the server into services/database/ so the server stays a clean, standalone deployable API.

### What moved
- CONTAINERS dict + ensure_containers from server/src/config/cosmos.py to services/database/cosmos_setup.py (setup-time only)
- Seed script from server/src/scripts/seed.py to services/database/seed.py (local dev tool)

### What stays in server
- Slim Cosmos client (get_cosmos_client, get_database, get_container) for runtime
- CosmosRepository + factory functions (query/API logic)
- Pydantic models (API data contracts)

### New convention
Non-API service configs (DB setup, AI Search index creation, seeding) live in services/. The server only contains runtime API logic.

### How to seed
cd services && uv run python -m database.seed
