### PR TITLE
feat(api): enforce tag name uniqueness on create and update

### DIFF
--- a/server/src/routes/tags.py
+++ b/server/src/routes/tags.py
@@ -33,6 +33,21 @@ def _run_name_validation(name: str) -> None:
         )
 
 
+def _check_name_unique(name: str, exclude_id: str | None = None) -> None:
+    """Raise HTTPException 400 if a tag with this name already exists."""
+    repo = get_tags_repo()
+    existing = repo.query(
+        "SELECT c.id FROM c WHERE c.name = @name",
+        parameters=[{"name": "@name", "value": name}],
+    )
+    for item in existing:
+        if item["id"] != exclude_id:
+            raise HTTPException(
+                status_code=400,
+                detail=_error("A tag with this name already exists"),
+            )
+
+
 class ValidateNameRequest(BaseModel):
     name: str
 
@@ -112,6 +127,7 @@ async def get_tag(tag_id: str) -> dict:
 async def create_tag(body: CreateTag) -> dict:
     """Create a new tag. Status defaults to draft."""
     _run_name_validation(body.name)
+    _check_name_unique(body.name)
     repo = get_tags_repo()
     tag = Tag(**body.model_dump())
     return repo.create(tag.model_dump(mode="json"))
@@ -132,6 +148,7 @@ async def update_tag(tag_id: str, body: UpdateTag) -> dict:
     # Validate name if it is being changed
     if "name" in updates:
         _run_name_validation(updates["name"])
+        _check_name_unique(updates["name"], exclude_id=tag_id)
 
     # Find the tag first (cross-partition)
     items = repo.query(

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -64,6 +64,10 @@ class FakeRepository:
         if "@assetId" in params:
             items = [i for i in items if i.get("assetId") == params["@assetId"]]
 
+        # Filter by name
+        if "@name" in params:
+            items = [i for i in items if i.get("name") == params["@name"]]
+
         # Filter by search
         if "@search" in params:
             term = params["@search"].lower()

--- a/server/tests/test_tags.py
+++ b/server/tests/test_tags.py
@@ -70,7 +70,7 @@ class TestListTags:
 
     def test_list_filter_by_asset_id(self, client):
         client.post("/api/tags", json=VALID_TAG_PAYLOAD)
-        other = {**VALID_TAG_PAYLOAD, "assetId": "asset-999"}
+        other = {**VALID_TAG_PAYLOAD, "name": "MUN.L2.PMP002.InletPressure", "assetId": "asset-999"}
         client.post("/api/tags", json=other)
 
         resp = client.get("/api/tags?assetId=asset-001")


### PR DESCRIPTION
## Summary

Add tag name uniqueness enforcement to the tags API.

### Changes
- **\_check_name_unique()\ helper** — cross-partition query checks for existing tags with the same name
- **\POST /api/tags\** — rejects creation if name already exists (400)
- **\PUT /api/tags/:id\** — rejects update if new name conflicts (excludes self via \xclude_id\)
- **Test fixtures** updated to use distinct names since duplicates are now rejected

### Why
Tag name uniqueness was not enforced anywhere — no DB constraint, no application logic. Two tags with identical names could be silently created, which is dangerous in OT environments where tag identity is critical for data lineage and alerting.

### Testing
- 91/91 backend tests pass
- Existing test updated: \	est_list_filter_by_asset_id\ now uses a distinct second tag name