### PR TITLE
fix(form): fix Dropdown display text disappearing on selection

### DIFF
--- a/client/src/components/TagForm.tsx
+++ b/client/src/components/TagForm.tsx
@@ -330,7 +330,7 @@ export default function TagForm({
           <Dropdown
             disabled={isAssetDisabled}
             placeholder="Select site"
-            value={form.site || undefined}
+            value={form.site}
             selectedOptions={form.site ? [form.site] : []}
             onOptionSelect={(_e, data) =>
               handleSiteChange(data.optionValue ?? "")
@@ -355,7 +355,7 @@ export default function TagForm({
           <Dropdown
             disabled={isAssetDisabled || !form.site}
             placeholder="Select line"
-            value={form.line || undefined}
+            value={form.line}
             selectedOptions={form.line ? [form.line] : []}
             onOptionSelect={(_e, data) =>
               handleLineChange(data.optionValue ?? "")
@@ -393,7 +393,7 @@ export default function TagForm({
         <Dropdown
           value={
             CRITICALITY_OPTIONS.find((o) => o.value === form.criticality)
-              ?.label ?? "Medium"
+              ?.label ?? ""
           }
           selectedOptions={[form.criticality]}
           onOptionSelect={(_e, data) =>
@@ -440,7 +440,7 @@ export default function TagForm({
           <Dropdown
             disabled={isAssetDisabled || !form.line}
             placeholder="Select equipment"
-            value={form.equipment || undefined}
+            value={form.equipment}
             selectedOptions={form.equipment ? [form.equipment] : []}
             onOptionSelect={(_e, data) =>
               updateField("equipment", data.optionValue ?? "")
@@ -465,7 +465,7 @@ export default function TagForm({
             value={
               form.unit === OTHER_UNIT_VALUE
                 ? "Other..."
-                : form.unit || undefined
+                : form.unit
             }
             selectedOptions={form.unit ? [form.unit] : []}
             onOptionSelect={(_e, data) => {


### PR DESCRIPTION
Fluent UI v9 Dropdown treats \alue={undefined}\ as uncontrolled, causing the display text to vanish when cascading state changes trigger re-renders. Changed all Dropdowns to use \alue={form.field}\ (empty string when cleared) so the component stays fully controlled. Affects Site, Line, Equipment, Criticality, and Unit dropdowns in TagForm.