### PR TITLE
feat(client): connect create form to auto-fill API

### DIFF
--- a/client/src/api/mutations.ts
+++ b/client/src/api/mutations.ts
@@ -1,5 +1,5 @@
 import { fetchApi } from "./client";
-import type { Tag, CreateTag, ValidateNameResponse } from "../types/tag";
+import type { Tag, CreateTag, ValidateNameResponse, AutoFillResult } from "../types/tag";
 import type { L1Rule, CreateL1Rule, L2Rule, CreateL2Rule } from "../types/rule";
 
 export function createTag(data: CreateTag): Promise<Tag> {
@@ -88,5 +88,12 @@ export function fetchNextAvailableName(baseName: string): Promise<NextAvailableN
   return fetchApi<NextAvailableNameResponse>("/api/tags/next-available-name", {
     method: "POST",
     body: { baseName },
+  });
+}
+
+export function autoFillTag(query: string): Promise<AutoFillResult> {
+  return fetchApi<AutoFillResult>("/api/tags/auto-fill", {
+    method: "POST",
+    body: { query },
   });
 }

--- a/client/src/components/TagForm.tsx
+++ b/client/src/components/TagForm.tsx
@@ -9,16 +9,20 @@ import {
   Option,
   Button,
   Label,
+  Spinner,
   MessageBar,
   MessageBarBody,
 } from "@fluentui/react-components";
+import { SparkleRegular } from "@fluentui/react-icons";
 import { useAssets } from "../hooks/useAssets";
 import { useNextAvailableName } from "../hooks/useNextAvailableName";
+import { useAutoFill } from "../hooks/useAutoFill";
 import { generateBaseTagName } from "../utils/tagNameMappings";
 import type {
   Tag,
   CreateTag,
   Criticality,
+  AutoFillResult,
 } from "../types/tag";
 
 export interface TagFormProps {
@@ -99,6 +103,15 @@ const useStyles = makeStyles({
   advancedLabel: {
     paddingTop: tokens.spacingVerticalM,
   },
+  autoFillRow: {
+    display: "flex",
+    alignItems: "flex-end",
+    gap: tokens.spacingHorizontalM,
+  },
+  autoFillField: {
+    flex: 1,
+    minWidth: 0,
+  },
   actions: {
     display: "flex",
     gap: tokens.spacingHorizontalM,
@@ -124,6 +137,44 @@ export default function TagForm({
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [attempted, setAttempted] = useState(false);
+
+  // --- Auto-fill (create mode only) ---
+  const [autoFillQuery, setAutoFillQuery] = useState("");
+  const [autoFillBaseName, setAutoFillBaseName] = useState("");
+  const autoFill = useAutoFill();
+
+  const applyAutoFillResult = (result: AutoFillResult) => {
+    setForm((prev) => {
+      const next = { ...prev };
+      if (result.site) next.site = result.site;
+      if (result.line) next.line = result.line;
+      if (result.equipment) next.equipment = result.equipment;
+      if (result.description) next.description = result.description;
+      if (result.criticality) next.criticality = result.criticality as Criticality;
+      if (result.unit) {
+        const isPreset = UNIT_OPTIONS.includes(result.unit);
+        next.unit = isPreset ? result.unit : OTHER_UNIT_VALUE;
+        next.customUnit = isPreset ? "" : result.unit;
+      }
+      return next;
+    });
+    // Set the AI-derived base name for next-available-name resolution
+    if (result.name) {
+      setAutoFillBaseName(result.name);
+    }
+  };
+
+  const handleAutoFill = () => {
+    if (!autoFillQuery.trim()) return;
+    setSubmitError(null);
+    autoFill.mutate(autoFillQuery.trim(), {
+      onSuccess: applyAutoFillResult,
+      onError: (err) => {
+        const message = err instanceof Error ? err.message : "Auto-fill failed. Please try again.";
+        setSubmitError(message);
+      },
+    });
+  };
 
   // Pre-populate form in edit mode once assets load
   useEffect(() => {
@@ -180,10 +231,19 @@ export default function TagForm({
     form.unit === OTHER_UNIT_VALUE ? form.customUnit : form.unit;
 
   // --- Auto-generated tag name (both create and edit) ---
-  const baseName = generateBaseTagName(form.site, form.line, form.equipment, resolvedUnit);
+  const manualBaseName = generateBaseTagName(form.site, form.line, form.equipment, resolvedUnit);
+  // Prefer AI-derived base name; clear it when user changes form fields manually
+  const baseName = autoFillBaseName || manualBaseName;
   const { name: autoName, resolving: nameResolving } =
     useNextAvailableName(baseName);
   const effectiveName = autoName;
+
+  // Clear the AI base name when the user manually changes cascading fields
+  useEffect(() => {
+    if (autoFillBaseName && manualBaseName && manualBaseName !== autoFillBaseName) {
+      setAutoFillBaseName("");
+    }
+  }, [manualBaseName, autoFillBaseName]);
 
   // --- Field helpers ---
   const updateField = <K extends keyof FormState>(
@@ -277,6 +337,30 @@ export default function TagForm({
         <MessageBar intent="error">
           <MessageBarBody>{submitError}</MessageBarBody>
         </MessageBar>
+      )}
+
+      {/* Auto-fill section (create mode only) */}
+      {mode === "create" && (
+        <div className={styles.autoFillRow}>
+          <Field className={styles.autoFillField} label="Describe your tag">
+            <Textarea
+              value={autoFillQuery}
+              onChange={(_e, data) => setAutoFillQuery(data.value)}
+              placeholder="e.g. outlet pressure sensor on the main cooling pump in Luxembourg Line 1"
+              rows={2}
+              resize="vertical"
+              disabled={autoFill.isPending}
+            />
+          </Field>
+          <Button
+            appearance="primary"
+            icon={autoFill.isPending ? <Spinner size="tiny" /> : <SparkleRegular />}
+            onClick={handleAutoFill}
+            disabled={autoFill.isPending || !autoFillQuery.trim()}
+          >
+            {autoFill.isPending ? "Filling..." : "Auto-fill"}
+          </Button>
+        </div>
       )}
 
       {/* Row 1: Site + Line (side by side) */}

--- a/client/src/hooks/useAutoFill.ts
+++ b/client/src/hooks/useAutoFill.ts
@@ -1,0 +1,8 @@
+import { useMutation } from "@tanstack/react-query";
+import { autoFillTag } from "../api/mutations";
+
+export function useAutoFill() {
+  return useMutation({
+    mutationFn: (query: string) => autoFillTag(query),
+  });
+}

--- a/client/src/types/tag.ts
+++ b/client/src/types/tag.ts
@@ -65,3 +65,34 @@ export interface ValidateNameResponse {
   valid: boolean;
   errors: NameValidationError[];
 }
+
+/** Request body for POST /api/tags/auto-fill */
+export interface AutoFillRequest {
+  query: string;
+}
+
+/** A single search hit from the golden-tags index */
+export interface AutoFillMatch {
+  tagName: string;
+  description: string;
+  score: number;
+  site: string;
+  line: string;
+  equipment: string;
+  unit: string;
+  datatype: string;
+}
+
+/** Response from POST /api/tags/auto-fill */
+export interface AutoFillResult {
+  site: string | null;
+  line: string | null;
+  equipment: string | null;
+  unit: string | null;
+  datatype: string | null;
+  name: string | null;
+  description: string | null;
+  criticality: string | null;
+  confidence: number;
+  matches: AutoFillMatch[];
+}


### PR DESCRIPTION
Connect the create tag form to the Auto-fill API. Users type a free-text description, click Auto-fill, and all form fields populate automatically from AI-powered hybrid search + LLM extraction.