### PR TITLE
feat: add language normalisation for non-English tag descriptions

### DIFF
--- a/client/src/api/mutations.ts
+++ b/client/src/api/mutations.ts
@@ -1,5 +1,5 @@
 import { fetchApi } from "./client";
-import type { Tag, CreateTag, ValidateNameResponse } from "../types/tag";
+import type { Tag, CreateTag, ValidateNameResponse, AutoFillResult } from "../types/tag";
 import type { L1Rule, CreateL1Rule, L2Rule, CreateL2Rule } from "../types/rule";
 
 export function createTag(data: CreateTag): Promise<Tag> {
@@ -88,5 +88,12 @@ export function fetchNextAvailableName(baseName: string): Promise<NextAvailableN
   return fetchApi<NextAvailableNameResponse>("/api/tags/next-available-name", {
     method: "POST",
     body: { baseName },
+  });
+}
+
+export function autoFillTag(query: string): Promise<AutoFillResult> {
+  return fetchApi<AutoFillResult>("/api/tags/auto-fill", {
+    method: "POST",
+    body: { query },
   });
 }

--- a/client/src/api/mutations.ts
+++ b/client/src/api/mutations.ts
@@ -1,5 +1,5 @@
 import { fetchApi } from "./client";
-import type { Tag, CreateTag, ValidateNameResponse, AutoFillResult } from "../types/tag";
+import type { Tag, CreateTag, ValidateNameResponse, AutoFillResult, TranslateResponse } from "../types/tag";
 import type { L1Rule, CreateL1Rule, L2Rule, CreateL2Rule } from "../types/rule";
 
 export function createTag(data: CreateTag): Promise<Tag> {
@@ -95,5 +95,12 @@ export function autoFillTag(query: string): Promise<AutoFillResult> {
   return fetchApi<AutoFillResult>("/api/tags/auto-fill", {
     method: "POST",
     body: { query },
+  });
+}
+
+export function translateText(text: string): Promise<TranslateResponse> {
+  return fetchApi<TranslateResponse>("/api/tags/translate", {
+    method: "POST",
+    body: { text },
   });
 }

--- a/client/src/components/TagForm.tsx
+++ b/client/src/components/TagForm.tsx
@@ -9,16 +9,20 @@ import {
   Option,
   Button,
   Label,
+  Spinner,
   MessageBar,
   MessageBarBody,
 } from "@fluentui/react-components";
+import { SparkleRegular } from "@fluentui/react-icons";
 import { useAssets } from "../hooks/useAssets";
 import { useNextAvailableName } from "../hooks/useNextAvailableName";
+import { useAutoFill } from "../hooks/useAutoFill";
 import { generateBaseTagName } from "../utils/tagNameMappings";
 import type {
   Tag,
   CreateTag,
   Criticality,
+  AutoFillResult,
 } from "../types/tag";
 
 export interface TagFormProps {
@@ -99,6 +103,15 @@ const useStyles = makeStyles({
   advancedLabel: {
     paddingTop: tokens.spacingVerticalM,
   },
+  autoFillRow: {
+    display: "flex",
+    alignItems: "flex-end",
+    gap: tokens.spacingHorizontalM,
+  },
+  autoFillField: {
+    flex: 1,
+    minWidth: 0,
+  },
   actions: {
     display: "flex",
     gap: tokens.spacingHorizontalM,
@@ -124,6 +137,44 @@ export default function TagForm({
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [attempted, setAttempted] = useState(false);
+
+  // --- Auto-fill (create mode only) ---
+  const [autoFillQuery, setAutoFillQuery] = useState("");
+  const [autoFillBaseName, setAutoFillBaseName] = useState("");
+  const autoFill = useAutoFill();
+
+  const applyAutoFillResult = (result: AutoFillResult) => {
+    setForm((prev) => {
+      const next = { ...prev };
+      if (result.site) next.site = result.site;
+      if (result.line) next.line = result.line;
+      if (result.equipment) next.equipment = result.equipment;
+      if (result.description) next.description = result.description;
+      if (result.criticality) next.criticality = result.criticality as Criticality;
+      if (result.unit) {
+        const isPreset = UNIT_OPTIONS.includes(result.unit);
+        next.unit = isPreset ? result.unit : OTHER_UNIT_VALUE;
+        next.customUnit = isPreset ? "" : result.unit;
+      }
+      return next;
+    });
+    // Set the AI-derived base name for next-available-name resolution
+    if (result.name) {
+      setAutoFillBaseName(result.name);
+    }
+  };
+
+  const handleAutoFill = () => {
+    if (!autoFillQuery.trim()) return;
+    setSubmitError(null);
+    autoFill.mutate(autoFillQuery.trim(), {
+      onSuccess: applyAutoFillResult,
+      onError: (err) => {
+        const message = err instanceof Error ? err.message : "Auto-fill failed. Please try again.";
+        setSubmitError(message);
+      },
+    });
+  };
 
   // Pre-populate form in edit mode once assets load
   useEffect(() => {
@@ -180,10 +231,19 @@ export default function TagForm({
     form.unit === OTHER_UNIT_VALUE ? form.customUnit : form.unit;
 
   // --- Auto-generated tag name (both create and edit) ---
-  const baseName = generateBaseTagName(form.site, form.line, form.equipment, resolvedUnit);
+  const manualBaseName = generateBaseTagName(form.site, form.line, form.equipment, resolvedUnit);
+  // Prefer AI-derived base name; clear it when user changes form fields manually
+  const baseName = autoFillBaseName || manualBaseName;
   const { name: autoName, resolving: nameResolving } =
     useNextAvailableName(baseName);
   const effectiveName = autoName;
+
+  // Clear the AI base name when the user manually changes cascading fields
+  useEffect(() => {
+    if (autoFillBaseName && manualBaseName && manualBaseName !== autoFillBaseName) {
+      setAutoFillBaseName("");
+    }
+  }, [manualBaseName, autoFillBaseName]);
 
   // --- Field helpers ---
   const updateField = <K extends keyof FormState>(
@@ -277,6 +337,30 @@ export default function TagForm({
         <MessageBar intent="error">
           <MessageBarBody>{submitError}</MessageBarBody>
         </MessageBar>
+      )}
+
+      {/* Auto-fill section (create mode only) */}
+      {mode === "create" && (
+        <div className={styles.autoFillRow}>
+          <Field className={styles.autoFillField} label="Describe your tag">
+            <Textarea
+              value={autoFillQuery}
+              onChange={(_e, data) => setAutoFillQuery(data.value)}
+              placeholder="e.g. outlet pressure sensor on the main cooling pump in Luxembourg Line 1"
+              rows={2}
+              resize="vertical"
+              disabled={autoFill.isPending}
+            />
+          </Field>
+          <Button
+            appearance="primary"
+            icon={autoFill.isPending ? <Spinner size="tiny" /> : <SparkleRegular />}
+            onClick={handleAutoFill}
+            disabled={autoFill.isPending || !autoFillQuery.trim()}
+          >
+            {autoFill.isPending ? "Filling..." : "Auto-fill"}
+          </Button>
+        </div>
       )}
 
       {/* Row 1: Site + Line (side by side) */}

--- a/client/src/components/TagForm.tsx
+++ b/client/src/components/TagForm.tsx
@@ -13,10 +13,11 @@ import {
   MessageBar,
   MessageBarBody,
 } from "@fluentui/react-components";
-import { SparkleRegular } from "@fluentui/react-icons";
+import { SparkleRegular, TranslateRegular } from "@fluentui/react-icons";
 import { useAssets } from "../hooks/useAssets";
 import { useNextAvailableName } from "../hooks/useNextAvailableName";
 import { useAutoFill } from "../hooks/useAutoFill";
+import { useTranslate } from "../hooks/useTranslate";
 import { generateBaseTagName } from "../utils/tagNameMappings";
 import type {
   Tag,
@@ -142,6 +143,7 @@ export default function TagForm({
   const [autoFillQuery, setAutoFillQuery] = useState("");
   const [autoFillBaseName, setAutoFillBaseName] = useState("");
   const autoFill = useAutoFill();
+  const translate = useTranslate();
 
   const applyAutoFillResult = (result: AutoFillResult) => {
     setForm((prev) => {
@@ -171,6 +173,22 @@ export default function TagForm({
       onSuccess: applyAutoFillResult,
       onError: (err) => {
         const message = err instanceof Error ? err.message : "Auto-fill failed. Please try again.";
+        setSubmitError(message);
+      },
+    });
+  };
+
+  const handleTranslate = () => {
+    if (!autoFillQuery.trim()) return;
+    setSubmitError(null);
+    translate.mutate(autoFillQuery.trim(), {
+      onSuccess: (result) => {
+        if (result.wasTranslated) {
+          setAutoFillQuery(result.text);
+        }
+      },
+      onError: (err) => {
+        const message = err instanceof Error ? err.message : "Translation failed.";
         setSubmitError(message);
       },
     });
@@ -349,14 +367,23 @@ export default function TagForm({
               placeholder="e.g. outlet pressure sensor on the main cooling pump in Luxembourg Line 1"
               rows={2}
               resize="vertical"
-              disabled={autoFill.isPending}
+              disabled={autoFill.isPending || translate.isPending}
             />
           </Field>
+          <Button
+            appearance="subtle"
+            icon={translate.isPending ? <Spinner size="tiny" /> : <TranslateRegular />}
+            onClick={handleTranslate}
+            disabled={translate.isPending || autoFill.isPending || !autoFillQuery.trim()}
+            title="Translate to English"
+          >
+            {translate.isPending ? "Translating..." : "Translate"}
+          </Button>
           <Button
             appearance="primary"
             icon={autoFill.isPending ? <Spinner size="tiny" /> : <SparkleRegular />}
             onClick={handleAutoFill}
-            disabled={autoFill.isPending || !autoFillQuery.trim()}
+            disabled={autoFill.isPending || translate.isPending || !autoFillQuery.trim()}
           >
             {autoFill.isPending ? "Filling..." : "Auto-fill"}
           </Button>

--- a/client/src/hooks/useAutoFill.ts
+++ b/client/src/hooks/useAutoFill.ts
@@ -1,0 +1,8 @@
+import { useMutation } from "@tanstack/react-query";
+import { autoFillTag } from "../api/mutations";
+
+export function useAutoFill() {
+  return useMutation({
+    mutationFn: (query: string) => autoFillTag(query),
+  });
+}

--- a/client/src/hooks/useTranslate.ts
+++ b/client/src/hooks/useTranslate.ts
@@ -1,0 +1,8 @@
+import { useMutation } from "@tanstack/react-query";
+import { translateText } from "../api/mutations";
+
+export function useTranslate() {
+  return useMutation({
+    mutationFn: (text: string) => translateText(text),
+  });
+}

--- a/client/src/types/tag.ts
+++ b/client/src/types/tag.ts
@@ -66,6 +66,13 @@ export interface ValidateNameResponse {
   errors: NameValidationError[];
 }
 
+/** Response from POST /api/tags/translate */
+export interface TranslateResponse {
+  text: string;
+  sourceLanguage: string;
+  wasTranslated: boolean;
+}
+
 /** Request body for POST /api/tags/auto-fill */
 export interface AutoFillRequest {
   query: string;

--- a/client/src/types/tag.ts
+++ b/client/src/types/tag.ts
@@ -65,3 +65,34 @@ export interface ValidateNameResponse {
   valid: boolean;
   errors: NameValidationError[];
 }
+
+/** Request body for POST /api/tags/auto-fill */
+export interface AutoFillRequest {
+  query: string;
+}
+
+/** A single search hit from the golden-tags index */
+export interface AutoFillMatch {
+  tagName: string;
+  description: string;
+  score: number;
+  site: string;
+  line: string;
+  equipment: string;
+  unit: string;
+  datatype: string;
+}
+
+/** Response from POST /api/tags/auto-fill */
+export interface AutoFillResult {
+  site: string | null;
+  line: string | null;
+  equipment: string | null;
+  unit: string | null;
+  datatype: string | null;
+  name: string | null;
+  description: string | null;
+  criticality: string | null;
+  confidence: number;
+  matches: AutoFillMatch[];
+}

--- a/server/src/models/auto_fill.py
+++ b/server/src/models/auto_fill.py
@@ -9,6 +9,20 @@ class AutoFillRequest(BaseModel):
     query: str
 
 
+class TranslateRequest(BaseModel):
+    """Request body for ``POST /api/tags/translate``."""
+
+    text: str
+
+
+class TranslateResponse(BaseModel):
+    """Response from ``POST /api/tags/translate``."""
+
+    text: str
+    sourceLanguage: str
+    wasTranslated: bool
+
+
 class AutoFillMatch(BaseModel):
     """A single search hit from the golden-tags index."""
 

--- a/server/src/routes/auto_fill.py
+++ b/server/src/routes/auto_fill.py
@@ -4,8 +4,9 @@ import logging
 
 from fastapi import APIRouter, HTTPException
 
-from src.models.auto_fill import AutoFillRequest, AutoFillResult
+from src.models.auto_fill import AutoFillRequest, AutoFillResult, TranslateRequest, TranslateResponse
 from src.utils.search import SearchServiceError, auto_fill_tag
+from src.utils.translate import normalise_to_english
 
 logger = logging.getLogger("ot_tag_registry.routes.auto_fill")
 
@@ -25,3 +26,14 @@ async def auto_fill(body: AutoFillRequest) -> AutoFillResult:
         raise HTTPException(status_code=400, detail={"error": str(exc)}) from exc
 
     return result
+
+
+@router.post("/translate", response_model=TranslateResponse)
+async def translate(body: TranslateRequest) -> TranslateResponse:
+    """Translate free-text to English using Azure Translator."""
+    result = await normalise_to_english(body.text)
+    return TranslateResponse(
+        text=result.text,
+        sourceLanguage=result.source_language,
+        wasTranslated=result.was_translated,
+    )

--- a/server/src/utils/search.py
+++ b/server/src/utils/search.py
@@ -321,6 +321,54 @@ def _extract_structured_fields(
 
 
 # ---------------------------------------------------------------------------
+# Search execution with retry on stale SSL connections
+# ---------------------------------------------------------------------------
+
+
+def _execute_search(
+    query: str,
+    vector_query: VectorizedQuery,
+    top_k: int,
+) -> list[AutoFillMatch]:
+    """Run the hybrid search, retrying once with a fresh client on SSL errors."""
+    global _cached_search_client
+
+    for attempt in range(2):
+        try:
+            client = _get_search_client()
+            results = client.search(
+                search_text=query,
+                vector_queries=[vector_query],
+                select=_SELECT_FIELDS,
+                top=top_k,
+            )
+
+            matches: list[AutoFillMatch] = []
+            for result in results:
+                matches.append(
+                    AutoFillMatch(
+                        tagName=result["tagName"],
+                        description=result.get("description", ""),
+                        score=result["@search.score"],
+                        site=result.get("site", ""),
+                        line=result.get("line", ""),
+                        equipment=result.get("equipment", ""),
+                        unit=result.get("unit", ""),
+                        datatype=result.get("datatype", ""),
+                    )
+                )
+            return matches
+        except (HttpResponseError, ServiceRequestError) as exc:
+            if attempt == 0:
+                logger.warning("Search failed (attempt 1), retrying with fresh client: %s", exc)
+                _cached_search_client = None
+                continue
+            raise SearchServiceError(f"Search query failed: {exc}") from exc
+
+    return []  # unreachable, but satisfies type checker
+
+
+# ---------------------------------------------------------------------------
 # Main query function
 # ---------------------------------------------------------------------------
 
@@ -343,8 +391,13 @@ async def auto_fill_tag(
         SearchServiceError: If the embedding or search API call fails.
         ValueError: If required environment variables are missing.
     """
-    # 1. Generate embedding
-    embedding = _generate_query_embedding(query)
+    # 0. Normalise query to English (non-blocking — falls back to original)
+    from src.utils.translate import normalise_to_english as _translate
+    translate_result = await _translate(query)
+    normalised_query = translate_result.text
+
+    # 1. Generate embedding (from normalised text)
+    embedding = _generate_query_embedding(normalised_query)
 
     # 2. Build vector query
     vector_query = VectorizedQuery(
@@ -354,34 +407,14 @@ async def auto_fill_tag(
     )
 
     # 3. Execute hybrid search (keyword + vector, no OData filter)
-    try:
-        client = _get_search_client()
-        results = client.search(
-            search_text=query,
-            vector_queries=[vector_query],
-            select=_SELECT_FIELDS,
-            top=top_k,
-        )
-
-        matches: list[AutoFillMatch] = []
-        for result in results:
-            matches.append(
-                AutoFillMatch(
-                    tagName=result["tagName"],
-                    description=result.get("description", ""),
-                    score=result["@search.score"],
-                    site=result.get("site", ""),
-                    line=result.get("line", ""),
-                    equipment=result.get("equipment", ""),
-                    unit=result.get("unit", ""),
-                    datatype=result.get("datatype", ""),
-                )
-            )
-    except (HttpResponseError, ServiceRequestError) as exc:
-        raise SearchServiceError(f"Search query failed: {exc}") from exc
+    #    Run the sync SearchClient off the event loop and retry once on
+    #    transient SSL errors (stale cached connection).
+    matches = await asyncio.to_thread(
+        _execute_search, normalised_query, vector_query, top_k,
+    )
 
     # 4. Agent extraction (sync HTTP calls — run off the event loop)
-    extracted = await asyncio.to_thread(_extract_structured_fields, query, matches)
+    extracted = await asyncio.to_thread(_extract_structured_fields, normalised_query, matches)
 
     # 5. Build result
     confidence = matches[0].score if matches else 0.0

--- a/server/src/utils/translate.py
+++ b/server/src/utils/translate.py
@@ -1,0 +1,90 @@
+"""Language normalisation — translates free-text to English via Azure Translator.
+
+Uses the Translator endpoint exposed through the AI Services (Cognitive Services)
+resource.  Auto-detects the source language and translates to English.
+
+Required environment variable:
+    AI_SERVICES_ENDPOINT  — e.g. https://<resource>.cognitiveservices.azure.com/
+
+Authentication uses ``DefaultAzureCredential`` (Entra ID).
+"""
+
+import logging
+import os
+
+import httpx
+from azure.identity import DefaultAzureCredential
+
+logger = logging.getLogger("ot_tag_registry.translate")
+
+_TRANSLATE_API_VERSION = "2024-11-01"
+_TARGET_LANGUAGE = "en"
+_SCOPE = "https://cognitiveservices.azure.com/.default"
+
+_cached_credential: DefaultAzureCredential | None = None
+
+
+def _get_credential() -> DefaultAzureCredential:
+    global _cached_credential
+    if _cached_credential is None:
+        _cached_credential = DefaultAzureCredential()
+    return _cached_credential
+
+
+class TranslateResult:
+    """Holds the translation result."""
+
+    def __init__(self, text: str, source_language: str, was_translated: bool):
+        self.text = text
+        self.source_language = source_language
+        self.was_translated = was_translated
+
+
+async def normalise_to_english(text: str) -> TranslateResult:
+    """Translate *text* to English.  Returns the original text on any failure.
+
+    Non-blocking: if translation fails the original text is returned so
+    downstream search still works.
+    """
+    endpoint = os.environ.get("AI_SERVICES_ENDPOINT", "").rstrip("/")
+    if not endpoint:
+        logger.warning("AI_SERVICES_ENDPOINT not set — skipping translation")
+        return TranslateResult(text=text, source_language="unknown", was_translated=False)
+
+    try:
+        token = _get_credential().get_token(_SCOPE).token
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+        url = (
+            f"{endpoint}/translator/text/translate"
+            f"?api-version={_TRANSLATE_API_VERSION}"
+        )
+        body = {
+            "inputs": [
+                {
+                    "Text": text,
+                    "targets": [{"language": _TARGET_LANGUAGE}],
+                }
+            ]
+        }
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(url, headers=headers, json=body, timeout=10)
+            response.raise_for_status()
+            data = response.json()
+
+        translated = data["value"][0]["translations"][0]["text"]
+        detected = data["value"][0].get("detectedLanguage", {}).get("language", "unknown")
+
+        if detected == _TARGET_LANGUAGE:
+            logger.debug("Text already in English — no translation needed")
+            return TranslateResult(text=text, source_language=detected, was_translated=False)
+
+        logger.info("Translated from %s: %r -> %r", detected, text, translated)
+        return TranslateResult(text=translated, source_language=detected, was_translated=True)
+
+    except Exception:
+        logger.exception("Translation failed — proceeding with original text")
+        return TranslateResult(text=text, source_language="unknown", was_translated=False)

--- a/services/language/normalise.py
+++ b/services/language/normalise.py
@@ -1,0 +1,79 @@
+"""Language normalisation — translates free-text to English via Azure Translator.
+
+Uses the Translator endpoint exposed through the AI Services (Cognitive Services)
+resource.  Auto-detects the source language and translates to English.
+
+Required environment variable:
+    AI_SERVICES_ENDPOINT  — e.g. https://<resource>.cognitiveservices.azure.com/
+
+Authentication uses ``DefaultAzureCredential`` (Entra ID).
+"""
+
+import logging
+import os
+
+import requests
+from azure.identity import DefaultAzureCredential
+
+logger = logging.getLogger(__name__)
+
+_TRANSLATE_API_VERSION = "2024-11-01"
+_TARGET_LANGUAGE = "en"
+_SCOPE = "https://cognitiveservices.azure.com/.default"
+
+_cached_credential: DefaultAzureCredential | None = None
+
+
+def _get_credential() -> DefaultAzureCredential:
+    global _cached_credential
+    if _cached_credential is None:
+        _cached_credential = DefaultAzureCredential()
+    return _cached_credential
+
+
+def normalise_to_english(text: str) -> str:
+    """Translate *text* to English.  Returns the original text on any failure.
+
+    This is intentionally non-blocking at the caller level: if translation
+    fails for any reason the original text is returned so downstream search
+    still works.
+    """
+    endpoint = os.environ.get("AI_SERVICES_ENDPOINT", "").rstrip("/")
+    if not endpoint:
+        logger.warning("AI_SERVICES_ENDPOINT not set — skipping translation")
+        return text
+
+    try:
+        token = _get_credential().get_token(_SCOPE).token
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+        url = (
+            f"{endpoint}/translator/text/translate"
+            f"?api-version={_TRANSLATE_API_VERSION}"
+        )
+        body = {
+            "inputs": [
+                {
+                    "Text": text,
+                    "targets": [{"language": _TARGET_LANGUAGE}],
+                }
+            ]
+        }
+
+        response = requests.post(url, headers=headers, json=body, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+
+        translated = data["value"][0]["translations"][0]["text"]
+        detected = data["value"][0].get("detectedLanguage", {}).get("language", "unknown")
+        if detected == _TARGET_LANGUAGE:
+            logger.debug("Text already in English — no translation needed")
+            return text
+        logger.info("Translated from %s: %r -> %r", detected, text, translated)
+        return translated
+
+    except Exception:
+        logger.exception("Translation failed — proceeding with original text")
+        return text


### PR DESCRIPTION
Adds automatic translation of non-English tag descriptions to English before vector search, plus an explicit Translate button in the create form.

## Backend
- **services/language/normalise.py** — standalone translation module using Azure Translator (Cognitive Services)
- **server/src/utils/translate.py** — async translation utility for the server (httpx)
- **POST /api/tags/translate** — explicit translation endpoint
- Auto-fill flow now normalises the query to English before embedding generation and hybrid search
- Non-blocking: translation failure gracefully falls back to the original text

## Frontend
- **Translate** button (TranslateRegular icon) next to Auto-fill in the create form
- Replaces query text in-place so user can review the translation before auto-filling
- Loading/error states handled consistently with auto-fill

## Testing
- 114 backend tests pass
- Client build passes (tsc + vite)